### PR TITLE
Extracted method to unminify tree

### DIFF
--- a/README.md
+++ b/README.md
@@ -34,15 +34,27 @@ unminify /path/to/file.js
 ## API Usage
 
 ```js
-let unminify = require('unminify');
+let { unminifySource } = require('unminify');
 let sourceText = '/* a minified/"obfuscated" JavaScript program */';
 console.log(unminify(sourceText));
 
 // or, with options
-console.log(unminify(sourceText, {
+console.log(unminifySource(sourceText, {
   safety: unminify.safetyLevels.UNSAFE,
   additionalTransforms: [function(ast) { /* ... */ }],
 }));
+```
+
+If you already have a Shift tree then you can use `unminifyTree` to avoid the codegen & reparse cost.
+
+```js
+let { parseScript } = require('shift-parser');
+let { unminifyTree } = require('unminify');
+
+let sourceText = '/* a minified/"obfuscated" JavaScript program */';
+
+let tree = parseScript(sourceText);
+let unminifiedTree = unminifyTree(tree);
 ```
 
 ## Safety Levels

--- a/src/index.js
+++ b/src/index.js
@@ -20,10 +20,10 @@ const TRANSFORMATIONS = {
   ],
 };
 
-module.exports = function (src, options) {
+function unminifySource(src, options) {
   let tree = parser.parseScript(src);
   return codegen(unminifyTree(tree, options));
-};
+}
 
 function unminifyTree(tree, { safety = safetyLevels.SAFE, additionalTransforms = [] } = {}) {
   let transformations = [];
@@ -46,6 +46,7 @@ function unminifyTree(tree, { safety = safetyLevels.SAFE, additionalTransforms =
   return lastTree;
 }
 
+module.exports = unminifySource;
+module.exports.unminifySource = unminifySource;
 module.exports.unminifyTree = unminifyTree;
-
 module.exports.safetyLevels = safetyLevels;

--- a/src/index.js
+++ b/src/index.js
@@ -20,26 +20,32 @@ const TRANSFORMATIONS = {
   ],
 };
 
-module.exports = function (src, { safety = safetyLevels.SAFE, additionalTransforms = [] } = {}) {
+module.exports = function (src, options) {
   let tree = parser.parseScript(src);
+  return codegen(unminifyTree(tree, options));
+};
 
+function unminifyTree(tree, { safety = safetyLevels.SAFE, additionalTransforms = [] } = {}) {
   let transformations = [];
   for (let i = 0; i <= safety; ++i) {
     transformations.push(...TRANSFORMATIONS[i]);
   }
   transformations.push(...additionalTransforms);
 
+  let lastTree = tree;
   // cap at 100 on general principles, but theoretically `while (true)` should be ok
   for (let i = 0; i < 100; ++i) {
-    let newTree = tree;
+    let newTree = lastTree;
     for (let transformation of transformations) {
       newTree = transformation(newTree);
     }
-    if (newTree === tree) break;
-    tree = newTree;
+    if (newTree === lastTree) break;
+    lastTree = newTree;
   }
 
-  return codegen(tree);
-};
+  return lastTree;
+}
+
+module.exports.unminifyTree = unminifyTree;
 
 module.exports.safetyLevels = safetyLevels;


### PR DESCRIPTION
Addresses #11

This PR just separates out the tree processing to a new exposed method so that consumers who already have a tree don't need to codegen it.