### PR TITLE
Version 2.0.0

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "unminify",
-  "version": "1.1.0",
+  "version": "2.0.0",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "unminify",
-      "version": "1.1.0",
+      "version": "2.0.0",
       "license": "Apache-2.0",
       "dependencies": {
         "command-line-args": "5.2.1",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "unminify",
-  "version": "1.1.0",
+  "version": "2.0.0",
   "author": "Kevin Gibbons <kevin@shapesecurity.com>",
   "description": "reverse many of the transformations applied by minifiers and naïve obfuscators",
   "license": "Apache-2.0",


### PR DESCRIPTION
Calling this major because it drops support for ancient versions of node and also because if you're calling the `unminifyTree` API directly that now requires a different version of the AST format.